### PR TITLE
Fix typo in exception code and bug in packing types where bool(val) == False

### DIFF
--- a/pycassa/columnfamily.py
+++ b/pycassa/columnfamily.py
@@ -426,14 +426,14 @@ class ColumnFamily(object):
                             (value, d_type))
 
     def _pack_key(self, key):
-        if not self.autopack_keys or not key:
+        if not self.autopack_keys or key == '':
             return key
         try:
             return self._key_packer(key)
         except struct.error:
             d_type = self.key_validation_class
             raise TypeError("%s is not a compatible type for %s" %
-                            (value.__class__.__name__, d_type))
+                            (key.__class__.__name__, d_type))
 
     def _unpack_key(self, b):
         if not self.autopack_keys:


### PR DESCRIPTION
1. If using types, a type such that (not Val) is False will not by unpacked.  For example, use an int type and put a 0 in.
   Signed-off-by: Brandyn A. White bwhite@dappervision.com

You can test using this code

import pycassa

def get_column_family(column_fam):
    credentials = {}
    pool = pycassa.ConnectionPool('type_test', [SERVERS],
                                  credentials=credentials, pool_size=9)
    return pycassa.ColumnFamily(pool, column_fam)

cf = get_column_family('int_double_bool') # row validator=int, column validator=double, col val validator=bool
for x in range(10):
    cf.insert(x, dict(((float(y), y % 2 == 0)) for y in range(10)))
for x in cf.get_range():
    print(x)
