### PR TITLE
Small issue in the test README

### DIFF
--- a/tests/README
+++ b/tests/README
@@ -1,6 +1,6 @@
 To run the tests:
 1. Install python-nose (easy_install nose)
-2. Change Cassandra's cassandra.yaml to use OrderPreservingPartitioner
+2. Change Cassandra's cassandra.yaml to use ByteOrderedPartitioner
 3. If you want to test authN/authZ, use SimpleAuthenticator and SimpleAuthority
    in cassandra.yaml and start Cassandra with:
    bin/cassandra -f -Dpasswd.properties=conf/passwd.properties -Daccess.properties=conf/access.properties


### PR DESCRIPTION
Tests fail when using OrderPreservingPartitioner as it requires UTF-8
keys, and it's deprecated. Change to ByteOrderedPartitioner.
All tests pass.
