### PR TITLE
Align timeout default in connect with ConnectionPool

### DIFF
--- a/pycassa/connection.py
+++ b/pycassa/connection.py
@@ -74,7 +74,7 @@ class Connection(Cassandra.Client):
         self.transport.close()
 
 
-def connect(keyspace, servers=None, framed_transport=True, timeout=None,
+def connect(keyspace, servers=None, framed_transport=True, timeout=0.5,
             credentials=None, retry_time=60, recycle=None, use_threadlocal=True):
     """
     Constructs a :class:`~pycassa.pool.ConnectionPool`. This is primarily available


### PR DESCRIPTION
From the docs on the connect method:

 'All of the parameters here correspond directly with parameters of the same name in
    :meth:`pycassa.pool.ConnectionPool.**init**()'

This sets the default timeout to be the same. There are other defaults that may need to be updated as well, however this is the one that bit me.

Thanks!

Ian
