### PR TITLE
Added additional UUIDType to _BASIC_TYPES to fix UUID support in Cassandra 1.0.1

### DIFF
--- a/pycassa/marshal.py
+++ b/pycassa/marshal.py
@@ -27,7 +27,7 @@ else:
 _BASIC_TYPES = ['BytesType', 'LongType', 'IntegerType', 'UTF8Type',
                 'AsciiType', 'LexicalUUIDType', 'TimeUUIDType',
                 'CounterColumnType', 'FloatType', 'DoubleType',
-                'DateType', 'BooleanType']
+                'DateType', 'BooleanType', 'UUIDType']
 
 def extract_type_name(typestr):
     if typestr is None:


### PR DESCRIPTION
Cassandra 1.0.1 returns TimeUUIDType types like org.apache.cassandra.db.marshal.UUIDType, which is being missed in the current _BASIC_TYPES.  This commit properly flags UUID fields as UUIDType, not BytesType.
