### PR TITLE
Fix for _wait_for_agreement in system manager. 

### DIFF
--- a/pycassa/system_manager.py
+++ b/pycassa/system_manager.py
@@ -1,6 +1,5 @@
 import time
 import warnings
-import uuid
 
 from pycassa.connection import Connection
 from pycassa.cassandra.ttypes import IndexType, KsDef, CfDef, ColumnDef,\
@@ -590,11 +589,11 @@ class SystemManager(object):
     def _wait_for_agreement(self):
         while True:
             versions = self._conn.describe_schema_versions()
-            for key, _nodes in versions.items():
-                try:
-                    uuid.UUID(key)
-                except:
-                    continue
-                else:
-                    return True
-            time.sleep(_SAMPLE_PERIOD)
+
+            # ignore unreachable nodes
+            live_versions = [key for key in versions.keys() if key != 'UNREACHABLE']
+
+            if len(live_versions) == 1:
+               break
+            else:
+                time.sleep(_SAMPLE_PERIOD)


### PR DESCRIPTION
Fix for _wait_for_agreement in system manager. Now it works if some cluster's node is down.
