### PR TITLE
Add python-setuptools to debian build dependencies.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: pycassa
 Section: python
 Priority: optional
 Maintainer: paul cannon <paul@datastax.com>
-Build-Depends: debhelper (>= 7.0.50~), python-all, cdbs, python-support, python-sphinx, python-thrift (>= 0.5.0)
+Build-Depends: debhelper (>= 7.0.50~), python-all, cdbs, python-support, python-sphinx, python-thrift (>= 0.5.0), python-setuptools
 Standards-Version: 3.9.1
 
 Package: python-pycassa


### PR DESCRIPTION
The build requires it and places like Launchpad don't allow build-time fetching of external dependencies.
