### PR TITLE
fix issue with empty server list

### DIFF
--- a/pycassa/pool.py
+++ b/pycassa/pool.py
@@ -383,6 +383,8 @@ class ConnectionPool(object):
     def _create_connection(self):
         """Creates a ConnectionWrapper, which opens a
         pycassa.connection.Connection."""
+        if not self.server_list:
+            raise AllServersUnavailable('Cannot connect to any servers as server list is empty!')
         failure_count = 0
         while failure_count < 2 * len(self.server_list):
             try:

--- a/tests/test_connection_pooling.py
+++ b/tests/test_connection_pooling.py
@@ -4,7 +4,7 @@ import time
 
 from nose.tools import assert_raises, assert_equal
 from pycassa import ColumnFamily, ConnectionPool, PoolListener, InvalidRequestError,\
-                    NoConnectionAvailable, MaximumRetryException
+                    NoConnectionAvailable, MaximumRetryException, AllServersUnavailable
 
 _credentials = {'username':'jsmith', 'password':'havebadpass'}
 
@@ -24,6 +24,9 @@ class PoolingCase(unittest.TestCase):
         cf = ColumnFamily(pool, 'Standard1')
         cf.insert('key1', {'col':'val'})
         pool.dispose()
+
+    def test_empty_list(self):
+        assert_raises(AllServersUnavailable, ConnectionPool, 'PycassaTestKeyspace', server_list=[])
 
     def test_server_list_func(self):
         listener = _TestListener()


### PR DESCRIPTION
right now if server list is empty, like here:

``` python
def get_cass_address():
    return []

keyspace = "foobar"

pool = ConnectionPool(
    keyspace,
    get_cass_address()
)
```

pycassa crashes inside `ConnectionPool::_create_connection()` right after the while loop because `exc` isn't set (it's set inside while loop)

``` python
while failure_count < 2 * len(self.server_list):
    [...]
    here we set exc
    [...]
raise AllServersUnavailable('An attempt was made to connect to each of the servers ' +
                            'twice, but none of the attempts succeeded. The last failure was %s: %s' %
                            (exc.__class__.__name__, exc))
```
