### PR TITLE
fix erasing comment when alter a column family without giving comment.

### DIFF
--- a/pycassa/system_manager.py
+++ b/pycassa/system_manager.py
@@ -465,9 +465,9 @@ class SystemManager(object):
         self._cfdef_assign(row_cache_keys_to_save, cfdef, 'row_cache_keys_to_save')
         self._cfdef_assign(compression_options, cfdef, 'compression_options')
         self._cfdef_assign(merge_shards_chance, cfdef, 'merge_shards_chance')
+        self._cfdef_assign(comment, cfdef, 'comment')
 
         cfdef.replicate_on_write = replicate_on_write
-        cfdef.comment = comment
         cfdef.key_alias = key_alias
         if row_cache_provider:
             cfdef.row_cache_provider = row_cache_provider


### PR DESCRIPTION
Calling SystemManager.alter_column_family with no comment parameter causes the current comment to be erased. This patch propose a fix.
