### PR TITLE
add request and params in the info field so it can surface in callbacks

### DIFF
--- a/pycassa/pool.py
+++ b/pycassa/pool.py
@@ -109,6 +109,7 @@ class ConnectionWrapper(Connection):
     def _retry(cls, f):
         def new_f(self, *args, **kwargs):
             self.operation_count += 1
+            self.info['request'] = {'method':'f', 'args':args, 'kwargs':kwargs}
             try:
                 allow_retries = kwargs.pop('allow_retries', True)
                 if kwargs.pop('reset', False):

--- a/tests/test_connection_pooling.py
+++ b/tests/test_connection_pooling.py
@@ -5,6 +5,8 @@ import time
 from nose.tools import assert_raises, assert_equal
 from pycassa import ColumnFamily, ConnectionPool, PoolListener, InvalidRequestError,\
                     NoConnectionAvailable, MaximumRetryException
+from pycassa.cassandra.c10.ttypes import ColumnPath
+from pycassa.pool import ConnectionWrapper
 
 _credentials = {'username':'jsmith', 'password':'havebadpass'}
 
@@ -460,6 +462,28 @@ class PoolingCase(unittest.TestCase):
 
         pool.dispose()
 
+    def test_queue_failure_connection_info(self):
+        totest = {}
+        listener = _TestListenerRequestInfo(totest)
+        pool = ConnectionPool(pool_size=5, max_overflow=5, recycle=10000,
+                              prefill=True, max_retries=None,
+                              keyspace='PycassaTestKeyspace', credentials=_credentials,
+                              listeners=[listener], use_threadlocal=False,
+                              server_list=['localhost:9160'])
+
+        connection_wrapper = ConnectionWrapper(pool, None, 'PycassaTestKeyspace', 'localhost:9160')
+        #close it to force the error
+        connection_wrapper.close()
+
+        cp = ColumnPath('Standard1', column='1')
+
+        try:
+            connection_wrapper.get('greunt', cp, 1)
+        except MaximumRetryException:
+            pass
+        print totest
+        self.assertTrue('request' in totest['dic']['connection'].info)
+
 
 class _TestListener(PoolListener):
 
@@ -509,3 +533,16 @@ class _TestListener(PoolListener):
 
     def pool_at_max(self, dic):
         self.max_count += 1
+
+
+class _TestListenerRequestInfo(_TestListener):
+    """"""
+
+    def __init__(self, totest):
+        """Constructor for _TestListenerRequestInfo"""
+        super(_TestListenerRequestInfo, self).__init__()
+        self.totest = totest
+
+    def connection_failed(self, dic):
+        super(_TestListenerRequestInfo, self).connection_failed(dic)
+        self.totest['dic'] = dic


### PR DESCRIPTION
Hi,

I added the request paramters in the info field of the ConnectionWrapper object, this way they are surfaced in the listeners callback and you can act on them.

Thanks for considering

--Gilles
