### PR TITLE
Use gevent Queue when gevent monkey-patching is used.

### DIFF
--- a/pycassa/pool.py
+++ b/pycassa/pool.py
@@ -4,10 +4,11 @@ import time
 import threading
 import random
 import socket
+import sys
 
-try:
+if 'gevent.monkey' in sys.modules:
     from gevent import queue as Queue
-except ImportError:
+else:
     import Queue
 
 from thrift import Thrift


### PR DESCRIPTION
When using pycassa under gevent, the Pool starts acting up. While the gevent threading monkey-patching of Lock is supposedly sufficient for the Python stdlib Queue module, in reality there's other issues that pop up. This has led to hacky solutions like so:
https://github.com/phus/geventmonkey/blob/master/geventcassa.py

I'd prefer not to have a bunch of code in various pycassa projects that use gevent to all have to keep re-using this. Supporting gevent should ideally be in the library itself, in this case pycassa.

The original commit tested merely that gevent was present, but this seems problematic since it meant the gevent Queue would be used merely because it was present on the system even if things weren't being monkey-patched (thus indicating a clear use of gevent in the actual current process). The second commit cleans this up to check that gevent.monkey was already imported, and uses gevent's Queue in that case for proper gevent functionality of the pycassa Pool.
