### PR TITLE
Fixing bug in system_manager.alter_column_family() where default_validation_class is ignored

### DIFF
--- a/pycassa/system_manager.py
+++ b/pycassa/system_manager.py
@@ -467,6 +467,7 @@ class SystemManager(object):
         self._cfdef_assign(merge_shards_chance, cfdef, 'merge_shards_chance')
         self._cfdef_assign(comment, cfdef, 'comment')
 
+        cfdef.default_validation_class = self._qualify_type_class(default_validation_class)
         cfdef.replicate_on_write = replicate_on_write
         cfdef.key_alias = key_alias
         if row_cache_provider:

--- a/tests/test_system_manager.py
+++ b/tests/test_system_manager.py
@@ -63,6 +63,16 @@ class SystemManagerTest(unittest.TestCase):
         cf = ColumnFamily(pool, 'LongCF')
         cf.insert('key', {2: 2})
         assert_equal(cf.get('key')[2], 2)
+        
+    def test_alter_column_family_default_validation_class(self):
+        sys.create_column_family(TEST_KS, 'AlteredCF', default_validation_class=LONG_TYPE)
+        pool = ConnectionPool(TEST_KS)
+        cf = ColumnFamily(pool, 'AlteredCF')
+        assert_equal(cf.default_validation_class, "LongType")
+
+        sys.alter_column_family(TEST_KS, 'AlteredCF', default_validation_class=UTF8_TYPE)
+        cf = ColumnFamily(pool, 'AlteredCF')
+        assert_equal(cf.default_validation_class, "UTF8Type")
 
     def test_alter_column_super_cf(self):
         sys.create_column_family(TEST_KS, 'SuperCF', super=True,


### PR DESCRIPTION
I ran into a bug where it was impossible to update the default_validation_class using the alter_column_family command - the parameter is there but not used in the body.

I added a simple test case to show the failure. It might be worth writing something more comprehensive to ensure other parameters are being set properly.
