### PR TITLE
Better support for timezones with DateType (for #145)

### DIFF
--- a/pycassa/marshal.py
+++ b/pycassa/marshal.py
@@ -4,8 +4,8 @@ in Cassandra.
 """
 
 import uuid
-import time
 import struct
+import calendar
 from datetime import datetime
 
 import pycassa.util as util
@@ -74,7 +74,7 @@ def _get_composite_name(typestr):
 def _to_timestamp(v):
     # Expects Value to be either date or datetime
     try:
-        converted = time.mktime(v.timetuple())
+        converted = calendar.timegm(v.utctimetuple())
         converted = converted * 1e3 + getattr(v, 'microsecond', 0)/1e3
     except AttributeError:
         # Ints and floats are valid timestamps too
@@ -248,7 +248,7 @@ def unpacker_for(typestr):
         return lambda v: v
 
     elif data_type == 'DateType':
-        return lambda v: datetime.fromtimestamp(
+        return lambda v: datetime.utcfromtimestamp(
                 _long_packer.unpack(v)[0] / 1e3)
 
     elif data_type == 'BooleanType':

--- a/pycassa/util.py
+++ b/pycassa/util.py
@@ -6,7 +6,7 @@ available for use by others working with pycassa.
 
 import random
 import uuid
-import time
+import calendar
 import datetime
 
 __all__ = ['convert_time_to_uuid', 'convert_uuid_to_time', 'OrderedDict']
@@ -56,12 +56,18 @@ def convert_time_to_uuid(time_arg, lowest_val=True, randomize=False):
 
     :rtype: :class:`uuid.UUID`
 
+    .. versionchanged:: 1.7.0
+        Prior to 1.7.0, datetime objects were expected to be in
+        local time. In 1.7.0 and beyond, naive datetimes are
+        assumed to be in UTC and tz-aware objects will be
+        automatically converted to UTC.
+
     """
     if isinstance(time_arg, uuid.UUID):
         return time_arg
 
     if hasattr(time_arg, 'timetuple'):
-        seconds = int(time.mktime(time_arg.timetuple()))
+        seconds = int(calendar.timegm(time_arg.utctimetuple()))
         microseconds = (seconds * 1e6) + time_arg.time().microsecond
     elif type(time_arg) in _number_types:
         microseconds = int(time_arg * 1e6)

--- a/tests/test_autopacking.py
+++ b/tests/test_autopacking.py
@@ -921,19 +921,19 @@ class TestTimeUUIDs(unittest.TestCase):
         key = 'key1'
         timeline = []
 
-        timeline.append(datetime.now())
+        timeline.append(datetime.utcnow())
         time1 = uuid1()
         col1 = {time1:'0'}
         cf_time.insert(key, col1)
         time.sleep(1)
 
-        timeline.append(datetime.now())
+        timeline.append(datetime.utcnow())
         time2 = uuid1()
         col2 = {time2:'1'}
         cf_time.insert(key, col2)
         time.sleep(1)
 
-        timeline.append(datetime.now())
+        timeline.append(datetime.utcnow())
 
         cols = {time1:'0', time2:'1'}
 
@@ -1013,7 +1013,7 @@ class TestDateTypes(unittest.TestCase):
         self.cf = ColumnFamily(pool, 'Standard1')
         self.cf.column_validators['date'] = OldPycassaDateType()
 
-        d = datetime.now()
+        d = datetime.utcnow()
         self.cf.insert('key1', {'date': d})
         self._compare_dates(self.cf.get('key1')['date'], d)
 


### PR DESCRIPTION
This is a solution for #145 as discussed in that issue. I ended up not adding in pytz support as it complicated comparisons with naive `datetime` objects significantly for little gain (when it's as simple as `pytz.utc.localize(...)` for someone who _does_ want pytz support). It'd be relatively easy to add this change if desired, though the tests would need a lot of updating.

While dealing with the date marshalling, I also took the opportunity to clean up that Python <2.5 compatibility code for `struct.Struct`.
