### PR TITLE
Add missing SkipTest import

### DIFF
--- a/tests/test_autopacking.py
+++ b/tests/test_autopacking.py
@@ -7,6 +7,7 @@ from pycassa.types import *
 from pycassa.index import *
 from pycassa.cassandra.constants import *
 
+from nose import SkipTest
 from nose.tools import (assert_raises, assert_equal, assert_almost_equal,
                         assert_true)
 


### PR DESCRIPTION
This was raised while running tests against old C\* 0.8.x versions.
