### PR TITLE
Travis-ci CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
     - sudo service cassandra status
 
 install:
-    - bin/python setup.py develop
+    - python setup.py develop
 
 script:
-    - bin/nosetests -v
+    - nosetests -v


### PR DESCRIPTION
This adds the spec file required for travis-ci to work.

I've limited emails to myself for now, to make sure the tests run and report actual errors (instead of problems with the build system).

This will only work once the travis-ci hooks are enabled for the Github repo.
