### PR TITLE
Protocol 19.35.0 and thrift 0.9

### DIFF
--- a/pycassa/cassandra/Cassandra.py
+++ b/pycassa/cassandra/Cassandra.py
@@ -121,7 +121,7 @@ class Iface(object):
   def get_indexed_slices(self, column_parent, index_clause, column_predicate, consistency_level):
     """
     Returns the subset of columns specified in SlicePredicate for the rows matching the IndexClause
-    @Deprecated; use get_range_slices instead with range.row_filter specified
+    @deprecated use get_range_slices instead with range.row_filter specified
 
     Parameters:
      - column_parent
@@ -316,6 +316,16 @@ class Iface(object):
     """
     pass
 
+  def describe_splits_ex(self, cfName, start_token, end_token, keys_per_split):
+    """
+    Parameters:
+     - cfName
+     - start_token
+     - end_token
+     - keys_per_split
+    """
+    pass
+
   def system_add_column_family(self, cf_def):
     """
     adds a column family. returns the new schema id.
@@ -381,6 +391,15 @@ class Iface(object):
     """
     pass
 
+  def execute_cql3_query(self, query, compression, consistency):
+    """
+    Parameters:
+     - query
+     - compression
+     - consistency
+    """
+    pass
+
   def prepare_cql_query(self, query, compression):
     """
     Prepare a CQL (Cassandra Query Language) statement by compiling and returning
@@ -388,6 +407,14 @@ class Iface(object):
     - an id token of the compiled CQL stored on the server side.
     - a count of the discovered bound markers in the statement
 
+    Parameters:
+     - query
+     - compression
+    """
+    pass
+
+  def prepare_cql3_query(self, query, compression):
+    """
     Parameters:
      - query
      - compression
@@ -405,8 +432,19 @@ class Iface(object):
     """
     pass
 
+  def execute_prepared_cql3_query(self, itemId, values, consistency):
+    """
+    Parameters:
+     - itemId
+     - values
+     - consistency
+    """
+    pass
+
   def set_cql_version(self, version):
     """
+    @deprecated This is now a no-op. Please use the CQL3 specific methods instead.
+
     Parameters:
      - version
     """
@@ -796,7 +834,7 @@ class Client(Iface):
   def get_indexed_slices(self, column_parent, index_clause, column_predicate, consistency_level):
     """
     Returns the subset of columns specified in SlicePredicate for the rows matching the IndexClause
-    @Deprecated; use get_range_slices instead with range.row_filter specified
+    @deprecated use get_range_slices instead with range.row_filter specified
 
     Parameters:
      - column_parent
@@ -1487,6 +1525,44 @@ class Client(Iface):
       return result.success
     raise TApplicationException(TApplicationException.MISSING_RESULT, "trace_next_query failed: unknown result");
 
+  def describe_splits_ex(self, cfName, start_token, end_token, keys_per_split):
+    """
+    Parameters:
+     - cfName
+     - start_token
+     - end_token
+     - keys_per_split
+    """
+    self.send_describe_splits_ex(cfName, start_token, end_token, keys_per_split)
+    return self.recv_describe_splits_ex()
+
+  def send_describe_splits_ex(self, cfName, start_token, end_token, keys_per_split):
+    self._oprot.writeMessageBegin('describe_splits_ex', TMessageType.CALL, self._seqid)
+    args = describe_splits_ex_args()
+    args.cfName = cfName
+    args.start_token = start_token
+    args.end_token = end_token
+    args.keys_per_split = keys_per_split
+    args.write(self._oprot)
+    self._oprot.writeMessageEnd()
+    self._oprot.trans.flush()
+
+  def recv_describe_splits_ex(self, ):
+    (fname, mtype, rseqid) = self._iprot.readMessageBegin()
+    if mtype == TMessageType.EXCEPTION:
+      x = TApplicationException()
+      x.read(self._iprot)
+      self._iprot.readMessageEnd()
+      raise x
+    result = describe_splits_ex_result()
+    result.read(self._iprot)
+    self._iprot.readMessageEnd()
+    if result.success is not None:
+      return result.success
+    if result.ire is not None:
+      raise result.ire
+    raise TApplicationException(TApplicationException.MISSING_RESULT, "describe_splits_ex failed: unknown result");
+
   def system_add_column_family(self, cf_def):
     """
     adds a column family. returns the new schema id.
@@ -1746,6 +1822,48 @@ class Client(Iface):
       raise result.sde
     raise TApplicationException(TApplicationException.MISSING_RESULT, "execute_cql_query failed: unknown result");
 
+  def execute_cql3_query(self, query, compression, consistency):
+    """
+    Parameters:
+     - query
+     - compression
+     - consistency
+    """
+    self.send_execute_cql3_query(query, compression, consistency)
+    return self.recv_execute_cql3_query()
+
+  def send_execute_cql3_query(self, query, compression, consistency):
+    self._oprot.writeMessageBegin('execute_cql3_query', TMessageType.CALL, self._seqid)
+    args = execute_cql3_query_args()
+    args.query = query
+    args.compression = compression
+    args.consistency = consistency
+    args.write(self._oprot)
+    self._oprot.writeMessageEnd()
+    self._oprot.trans.flush()
+
+  def recv_execute_cql3_query(self, ):
+    (fname, mtype, rseqid) = self._iprot.readMessageBegin()
+    if mtype == TMessageType.EXCEPTION:
+      x = TApplicationException()
+      x.read(self._iprot)
+      self._iprot.readMessageEnd()
+      raise x
+    result = execute_cql3_query_result()
+    result.read(self._iprot)
+    self._iprot.readMessageEnd()
+    if result.success is not None:
+      return result.success
+    if result.ire is not None:
+      raise result.ire
+    if result.ue is not None:
+      raise result.ue
+    if result.te is not None:
+      raise result.te
+    if result.sde is not None:
+      raise result.sde
+    raise TApplicationException(TApplicationException.MISSING_RESULT, "execute_cql3_query failed: unknown result");
+
   def prepare_cql_query(self, query, compression):
     """
     Prepare a CQL (Cassandra Query Language) statement by compiling and returning
@@ -1784,6 +1902,40 @@ class Client(Iface):
     if result.ire is not None:
       raise result.ire
     raise TApplicationException(TApplicationException.MISSING_RESULT, "prepare_cql_query failed: unknown result");
+
+  def prepare_cql3_query(self, query, compression):
+    """
+    Parameters:
+     - query
+     - compression
+    """
+    self.send_prepare_cql3_query(query, compression)
+    return self.recv_prepare_cql3_query()
+
+  def send_prepare_cql3_query(self, query, compression):
+    self._oprot.writeMessageBegin('prepare_cql3_query', TMessageType.CALL, self._seqid)
+    args = prepare_cql3_query_args()
+    args.query = query
+    args.compression = compression
+    args.write(self._oprot)
+    self._oprot.writeMessageEnd()
+    self._oprot.trans.flush()
+
+  def recv_prepare_cql3_query(self, ):
+    (fname, mtype, rseqid) = self._iprot.readMessageBegin()
+    if mtype == TMessageType.EXCEPTION:
+      x = TApplicationException()
+      x.read(self._iprot)
+      self._iprot.readMessageEnd()
+      raise x
+    result = prepare_cql3_query_result()
+    result.read(self._iprot)
+    self._iprot.readMessageEnd()
+    if result.success is not None:
+      return result.success
+    if result.ire is not None:
+      raise result.ire
+    raise TApplicationException(TApplicationException.MISSING_RESULT, "prepare_cql3_query failed: unknown result");
 
   def execute_prepared_cql_query(self, itemId, values):
     """
@@ -1828,8 +1980,52 @@ class Client(Iface):
       raise result.sde
     raise TApplicationException(TApplicationException.MISSING_RESULT, "execute_prepared_cql_query failed: unknown result");
 
+  def execute_prepared_cql3_query(self, itemId, values, consistency):
+    """
+    Parameters:
+     - itemId
+     - values
+     - consistency
+    """
+    self.send_execute_prepared_cql3_query(itemId, values, consistency)
+    return self.recv_execute_prepared_cql3_query()
+
+  def send_execute_prepared_cql3_query(self, itemId, values, consistency):
+    self._oprot.writeMessageBegin('execute_prepared_cql3_query', TMessageType.CALL, self._seqid)
+    args = execute_prepared_cql3_query_args()
+    args.itemId = itemId
+    args.values = values
+    args.consistency = consistency
+    args.write(self._oprot)
+    self._oprot.writeMessageEnd()
+    self._oprot.trans.flush()
+
+  def recv_execute_prepared_cql3_query(self, ):
+    (fname, mtype, rseqid) = self._iprot.readMessageBegin()
+    if mtype == TMessageType.EXCEPTION:
+      x = TApplicationException()
+      x.read(self._iprot)
+      self._iprot.readMessageEnd()
+      raise x
+    result = execute_prepared_cql3_query_result()
+    result.read(self._iprot)
+    self._iprot.readMessageEnd()
+    if result.success is not None:
+      return result.success
+    if result.ire is not None:
+      raise result.ire
+    if result.ue is not None:
+      raise result.ue
+    if result.te is not None:
+      raise result.te
+    if result.sde is not None:
+      raise result.sde
+    raise TApplicationException(TApplicationException.MISSING_RESULT, "execute_prepared_cql3_query failed: unknown result");
+
   def set_cql_version(self, version):
     """
+    @deprecated This is now a no-op. Please use the CQL3 specific methods instead.
+
     Parameters:
      - version
     """
@@ -1891,6 +2087,7 @@ class Processor(Iface, TProcessor):
     self._processMap["describe_keyspace"] = Processor.process_describe_keyspace
     self._processMap["describe_splits"] = Processor.process_describe_splits
     self._processMap["trace_next_query"] = Processor.process_trace_next_query
+    self._processMap["describe_splits_ex"] = Processor.process_describe_splits_ex
     self._processMap["system_add_column_family"] = Processor.process_system_add_column_family
     self._processMap["system_drop_column_family"] = Processor.process_system_drop_column_family
     self._processMap["system_add_keyspace"] = Processor.process_system_add_keyspace
@@ -1898,8 +2095,11 @@ class Processor(Iface, TProcessor):
     self._processMap["system_update_keyspace"] = Processor.process_system_update_keyspace
     self._processMap["system_update_column_family"] = Processor.process_system_update_column_family
     self._processMap["execute_cql_query"] = Processor.process_execute_cql_query
+    self._processMap["execute_cql3_query"] = Processor.process_execute_cql3_query
     self._processMap["prepare_cql_query"] = Processor.process_prepare_cql_query
+    self._processMap["prepare_cql3_query"] = Processor.process_prepare_cql3_query
     self._processMap["execute_prepared_cql_query"] = Processor.process_execute_prepared_cql_query
+    self._processMap["execute_prepared_cql3_query"] = Processor.process_execute_prepared_cql3_query
     self._processMap["set_cql_version"] = Processor.process_set_cql_version
 
   def process(self, iprot, oprot):
@@ -2360,6 +2560,20 @@ class Processor(Iface, TProcessor):
     oprot.writeMessageEnd()
     oprot.trans.flush()
 
+  def process_describe_splits_ex(self, seqid, iprot, oprot):
+    args = describe_splits_ex_args()
+    args.read(iprot)
+    iprot.readMessageEnd()
+    result = describe_splits_ex_result()
+    try:
+      result.success = self._handler.describe_splits_ex(args.cfName, args.start_token, args.end_token, args.keys_per_split)
+    except InvalidRequestException as ire:
+      result.ire = ire
+    oprot.writeMessageBegin("describe_splits_ex", TMessageType.REPLY, seqid)
+    result.write(oprot)
+    oprot.writeMessageEnd()
+    oprot.trans.flush()
+
   def process_system_add_column_family(self, seqid, iprot, oprot):
     args = system_add_column_family_args()
     args.read(iprot)
@@ -2476,6 +2690,26 @@ class Processor(Iface, TProcessor):
     oprot.writeMessageEnd()
     oprot.trans.flush()
 
+  def process_execute_cql3_query(self, seqid, iprot, oprot):
+    args = execute_cql3_query_args()
+    args.read(iprot)
+    iprot.readMessageEnd()
+    result = execute_cql3_query_result()
+    try:
+      result.success = self._handler.execute_cql3_query(args.query, args.compression, args.consistency)
+    except InvalidRequestException as ire:
+      result.ire = ire
+    except UnavailableException as ue:
+      result.ue = ue
+    except TimedOutException as te:
+      result.te = te
+    except SchemaDisagreementException as sde:
+      result.sde = sde
+    oprot.writeMessageBegin("execute_cql3_query", TMessageType.REPLY, seqid)
+    result.write(oprot)
+    oprot.writeMessageEnd()
+    oprot.trans.flush()
+
   def process_prepare_cql_query(self, seqid, iprot, oprot):
     args = prepare_cql_query_args()
     args.read(iprot)
@@ -2486,6 +2720,20 @@ class Processor(Iface, TProcessor):
     except InvalidRequestException as ire:
       result.ire = ire
     oprot.writeMessageBegin("prepare_cql_query", TMessageType.REPLY, seqid)
+    result.write(oprot)
+    oprot.writeMessageEnd()
+    oprot.trans.flush()
+
+  def process_prepare_cql3_query(self, seqid, iprot, oprot):
+    args = prepare_cql3_query_args()
+    args.read(iprot)
+    iprot.readMessageEnd()
+    result = prepare_cql3_query_result()
+    try:
+      result.success = self._handler.prepare_cql3_query(args.query, args.compression)
+    except InvalidRequestException as ire:
+      result.ire = ire
+    oprot.writeMessageBegin("prepare_cql3_query", TMessageType.REPLY, seqid)
     result.write(oprot)
     oprot.writeMessageEnd()
     oprot.trans.flush()
@@ -2506,6 +2754,26 @@ class Processor(Iface, TProcessor):
     except SchemaDisagreementException as sde:
       result.sde = sde
     oprot.writeMessageBegin("execute_prepared_cql_query", TMessageType.REPLY, seqid)
+    result.write(oprot)
+    oprot.writeMessageEnd()
+    oprot.trans.flush()
+
+  def process_execute_prepared_cql3_query(self, seqid, iprot, oprot):
+    args = execute_prepared_cql3_query_args()
+    args.read(iprot)
+    iprot.readMessageEnd()
+    result = execute_prepared_cql3_query_result()
+    try:
+      result.success = self._handler.execute_prepared_cql3_query(args.itemId, args.values, args.consistency)
+    except InvalidRequestException as ire:
+      result.ire = ire
+    except UnavailableException as ue:
+      result.ue = ue
+    except TimedOutException as te:
+      result.te = te
+    except SchemaDisagreementException as sde:
+      result.sde = sde
+    oprot.writeMessageBegin("execute_prepared_cql3_query", TMessageType.REPLY, seqid)
     result.write(oprot)
     oprot.writeMessageEnd()
     oprot.trans.flush()
@@ -7146,6 +7414,191 @@ class trace_next_query_result(object):
   def __ne__(self, other):
     return not (self == other)
 
+class describe_splits_ex_args(object):
+  """
+  Attributes:
+   - cfName
+   - start_token
+   - end_token
+   - keys_per_split
+  """
+
+  thrift_spec = (
+    None, # 0
+    (1, TType.STRING, 'cfName', None, None, ), # 1
+    (2, TType.STRING, 'start_token', None, None, ), # 2
+    (3, TType.STRING, 'end_token', None, None, ), # 3
+    (4, TType.I32, 'keys_per_split', None, None, ), # 4
+  )
+
+  def __init__(self, cfName=None, start_token=None, end_token=None, keys_per_split=None,):
+    self.cfName = cfName
+    self.start_token = start_token
+    self.end_token = end_token
+    self.keys_per_split = keys_per_split
+
+  def read(self, iprot):
+    if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
+      fastbinary.decode_binary(self, iprot.trans, (self.__class__, self.thrift_spec))
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRING:
+          self.cfName = iprot.readString();
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.start_token = iprot.readString();
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.STRING:
+          self.end_token = iprot.readString();
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.I32:
+          self.keys_per_split = iprot.readI32();
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
+
+  def write(self, oprot):
+    if oprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and self.thrift_spec is not None and fastbinary is not None:
+      oprot.trans.write(fastbinary.encode_binary(self, (self.__class__, self.thrift_spec)))
+      return
+    oprot.writeStructBegin('describe_splits_ex_args')
+    if self.cfName is not None:
+      oprot.writeFieldBegin('cfName', TType.STRING, 1)
+      oprot.writeString(self.cfName)
+      oprot.writeFieldEnd()
+    if self.start_token is not None:
+      oprot.writeFieldBegin('start_token', TType.STRING, 2)
+      oprot.writeString(self.start_token)
+      oprot.writeFieldEnd()
+    if self.end_token is not None:
+      oprot.writeFieldBegin('end_token', TType.STRING, 3)
+      oprot.writeString(self.end_token)
+      oprot.writeFieldEnd()
+    if self.keys_per_split is not None:
+      oprot.writeFieldBegin('keys_per_split', TType.I32, 4)
+      oprot.writeI32(self.keys_per_split)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
+
+  def validate(self):
+    if self.cfName is None:
+      raise TProtocol.TProtocolException(message='Required field cfName is unset!')
+    if self.start_token is None:
+      raise TProtocol.TProtocolException(message='Required field start_token is unset!')
+    if self.end_token is None:
+      raise TProtocol.TProtocolException(message='Required field end_token is unset!')
+    if self.keys_per_split is None:
+      raise TProtocol.TProtocolException(message='Required field keys_per_split is unset!')
+    return
+
+
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.iteritems()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __ne__(self, other):
+    return not (self == other)
+
+class describe_splits_ex_result(object):
+  """
+  Attributes:
+   - success
+   - ire
+  """
+
+  thrift_spec = (
+    (0, TType.LIST, 'success', (TType.STRUCT,(CfSplit, CfSplit.thrift_spec)), None, ), # 0
+    (1, TType.STRUCT, 'ire', (InvalidRequestException, InvalidRequestException.thrift_spec), None, ), # 1
+  )
+
+  def __init__(self, success=None, ire=None,):
+    self.success = success
+    self.ire = ire
+
+  def read(self, iprot):
+    if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
+      fastbinary.decode_binary(self, iprot.trans, (self.__class__, self.thrift_spec))
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 0:
+        if ftype == TType.LIST:
+          self.success = []
+          (_etype334, _size331) = iprot.readListBegin()
+          for _i335 in xrange(_size331):
+            _elem336 = CfSplit()
+            _elem336.read(iprot)
+            self.success.append(_elem336)
+          iprot.readListEnd()
+        else:
+          iprot.skip(ftype)
+      elif fid == 1:
+        if ftype == TType.STRUCT:
+          self.ire = InvalidRequestException()
+          self.ire.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
+
+  def write(self, oprot):
+    if oprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and self.thrift_spec is not None and fastbinary is not None:
+      oprot.trans.write(fastbinary.encode_binary(self, (self.__class__, self.thrift_spec)))
+      return
+    oprot.writeStructBegin('describe_splits_ex_result')
+    if self.success is not None:
+      oprot.writeFieldBegin('success', TType.LIST, 0)
+      oprot.writeListBegin(TType.STRUCT, len(self.success))
+      for iter337 in self.success:
+        iter337.write(oprot)
+      oprot.writeListEnd()
+      oprot.writeFieldEnd()
+    if self.ire is not None:
+      oprot.writeFieldBegin('ire', TType.STRUCT, 1)
+      self.ire.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
+
+  def validate(self):
+    return
+
+
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.iteritems()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __ne__(self, other):
+    return not (self == other)
+
 class system_add_column_family_args(object):
   """
   Attributes:
@@ -8220,6 +8673,208 @@ class execute_cql_query_result(object):
   def __ne__(self, other):
     return not (self == other)
 
+class execute_cql3_query_args(object):
+  """
+  Attributes:
+   - query
+   - compression
+   - consistency
+  """
+
+  thrift_spec = (
+    None, # 0
+    (1, TType.STRING, 'query', None, None, ), # 1
+    (2, TType.I32, 'compression', None, None, ), # 2
+    (3, TType.I32, 'consistency', None, None, ), # 3
+  )
+
+  def __init__(self, query=None, compression=None, consistency=None,):
+    self.query = query
+    self.compression = compression
+    self.consistency = consistency
+
+  def read(self, iprot):
+    if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
+      fastbinary.decode_binary(self, iprot.trans, (self.__class__, self.thrift_spec))
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRING:
+          self.query = iprot.readString();
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.I32:
+          self.compression = iprot.readI32();
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.I32:
+          self.consistency = iprot.readI32();
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
+
+  def write(self, oprot):
+    if oprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and self.thrift_spec is not None and fastbinary is not None:
+      oprot.trans.write(fastbinary.encode_binary(self, (self.__class__, self.thrift_spec)))
+      return
+    oprot.writeStructBegin('execute_cql3_query_args')
+    if self.query is not None:
+      oprot.writeFieldBegin('query', TType.STRING, 1)
+      oprot.writeString(self.query)
+      oprot.writeFieldEnd()
+    if self.compression is not None:
+      oprot.writeFieldBegin('compression', TType.I32, 2)
+      oprot.writeI32(self.compression)
+      oprot.writeFieldEnd()
+    if self.consistency is not None:
+      oprot.writeFieldBegin('consistency', TType.I32, 3)
+      oprot.writeI32(self.consistency)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
+
+  def validate(self):
+    if self.query is None:
+      raise TProtocol.TProtocolException(message='Required field query is unset!')
+    if self.compression is None:
+      raise TProtocol.TProtocolException(message='Required field compression is unset!')
+    if self.consistency is None:
+      raise TProtocol.TProtocolException(message='Required field consistency is unset!')
+    return
+
+
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.iteritems()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __ne__(self, other):
+    return not (self == other)
+
+class execute_cql3_query_result(object):
+  """
+  Attributes:
+   - success
+   - ire
+   - ue
+   - te
+   - sde
+  """
+
+  thrift_spec = (
+    (0, TType.STRUCT, 'success', (CqlResult, CqlResult.thrift_spec), None, ), # 0
+    (1, TType.STRUCT, 'ire', (InvalidRequestException, InvalidRequestException.thrift_spec), None, ), # 1
+    (2, TType.STRUCT, 'ue', (UnavailableException, UnavailableException.thrift_spec), None, ), # 2
+    (3, TType.STRUCT, 'te', (TimedOutException, TimedOutException.thrift_spec), None, ), # 3
+    (4, TType.STRUCT, 'sde', (SchemaDisagreementException, SchemaDisagreementException.thrift_spec), None, ), # 4
+  )
+
+  def __init__(self, success=None, ire=None, ue=None, te=None, sde=None,):
+    self.success = success
+    self.ire = ire
+    self.ue = ue
+    self.te = te
+    self.sde = sde
+
+  def read(self, iprot):
+    if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
+      fastbinary.decode_binary(self, iprot.trans, (self.__class__, self.thrift_spec))
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 0:
+        if ftype == TType.STRUCT:
+          self.success = CqlResult()
+          self.success.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 1:
+        if ftype == TType.STRUCT:
+          self.ire = InvalidRequestException()
+          self.ire.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRUCT:
+          self.ue = UnavailableException()
+          self.ue.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.STRUCT:
+          self.te = TimedOutException()
+          self.te.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.STRUCT:
+          self.sde = SchemaDisagreementException()
+          self.sde.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
+
+  def write(self, oprot):
+    if oprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and self.thrift_spec is not None and fastbinary is not None:
+      oprot.trans.write(fastbinary.encode_binary(self, (self.__class__, self.thrift_spec)))
+      return
+    oprot.writeStructBegin('execute_cql3_query_result')
+    if self.success is not None:
+      oprot.writeFieldBegin('success', TType.STRUCT, 0)
+      self.success.write(oprot)
+      oprot.writeFieldEnd()
+    if self.ire is not None:
+      oprot.writeFieldBegin('ire', TType.STRUCT, 1)
+      self.ire.write(oprot)
+      oprot.writeFieldEnd()
+    if self.ue is not None:
+      oprot.writeFieldBegin('ue', TType.STRUCT, 2)
+      self.ue.write(oprot)
+      oprot.writeFieldEnd()
+    if self.te is not None:
+      oprot.writeFieldBegin('te', TType.STRUCT, 3)
+      self.te.write(oprot)
+      oprot.writeFieldEnd()
+    if self.sde is not None:
+      oprot.writeFieldBegin('sde', TType.STRUCT, 4)
+      self.sde.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
+
+  def validate(self):
+    return
+
+
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.iteritems()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __ne__(self, other):
+    return not (self == other)
+
 class prepare_cql_query_args(object):
   """
   Attributes:
@@ -8369,6 +9024,155 @@ class prepare_cql_query_result(object):
   def __ne__(self, other):
     return not (self == other)
 
+class prepare_cql3_query_args(object):
+  """
+  Attributes:
+   - query
+   - compression
+  """
+
+  thrift_spec = (
+    None, # 0
+    (1, TType.STRING, 'query', None, None, ), # 1
+    (2, TType.I32, 'compression', None, None, ), # 2
+  )
+
+  def __init__(self, query=None, compression=None,):
+    self.query = query
+    self.compression = compression
+
+  def read(self, iprot):
+    if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
+      fastbinary.decode_binary(self, iprot.trans, (self.__class__, self.thrift_spec))
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRING:
+          self.query = iprot.readString();
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.I32:
+          self.compression = iprot.readI32();
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
+
+  def write(self, oprot):
+    if oprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and self.thrift_spec is not None and fastbinary is not None:
+      oprot.trans.write(fastbinary.encode_binary(self, (self.__class__, self.thrift_spec)))
+      return
+    oprot.writeStructBegin('prepare_cql3_query_args')
+    if self.query is not None:
+      oprot.writeFieldBegin('query', TType.STRING, 1)
+      oprot.writeString(self.query)
+      oprot.writeFieldEnd()
+    if self.compression is not None:
+      oprot.writeFieldBegin('compression', TType.I32, 2)
+      oprot.writeI32(self.compression)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
+
+  def validate(self):
+    if self.query is None:
+      raise TProtocol.TProtocolException(message='Required field query is unset!')
+    if self.compression is None:
+      raise TProtocol.TProtocolException(message='Required field compression is unset!')
+    return
+
+
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.iteritems()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __ne__(self, other):
+    return not (self == other)
+
+class prepare_cql3_query_result(object):
+  """
+  Attributes:
+   - success
+   - ire
+  """
+
+  thrift_spec = (
+    (0, TType.STRUCT, 'success', (CqlPreparedResult, CqlPreparedResult.thrift_spec), None, ), # 0
+    (1, TType.STRUCT, 'ire', (InvalidRequestException, InvalidRequestException.thrift_spec), None, ), # 1
+  )
+
+  def __init__(self, success=None, ire=None,):
+    self.success = success
+    self.ire = ire
+
+  def read(self, iprot):
+    if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
+      fastbinary.decode_binary(self, iprot.trans, (self.__class__, self.thrift_spec))
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 0:
+        if ftype == TType.STRUCT:
+          self.success = CqlPreparedResult()
+          self.success.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 1:
+        if ftype == TType.STRUCT:
+          self.ire = InvalidRequestException()
+          self.ire.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
+
+  def write(self, oprot):
+    if oprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and self.thrift_spec is not None and fastbinary is not None:
+      oprot.trans.write(fastbinary.encode_binary(self, (self.__class__, self.thrift_spec)))
+      return
+    oprot.writeStructBegin('prepare_cql3_query_result')
+    if self.success is not None:
+      oprot.writeFieldBegin('success', TType.STRUCT, 0)
+      self.success.write(oprot)
+      oprot.writeFieldEnd()
+    if self.ire is not None:
+      oprot.writeFieldBegin('ire', TType.STRUCT, 1)
+      self.ire.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
+
+  def validate(self):
+    return
+
+
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.iteritems()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __ne__(self, other):
+    return not (self == other)
+
 class execute_prepared_cql_query_args(object):
   """
   Attributes:
@@ -8403,10 +9207,10 @@ class execute_prepared_cql_query_args(object):
       elif fid == 2:
         if ftype == TType.LIST:
           self.values = []
-          (_etype334, _size331) = iprot.readListBegin()
-          for _i335 in xrange(_size331):
-            _elem336 = iprot.readString();
-            self.values.append(_elem336)
+          (_etype341, _size338) = iprot.readListBegin()
+          for _i342 in xrange(_size338):
+            _elem343 = iprot.readString();
+            self.values.append(_elem343)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -8427,8 +9231,8 @@ class execute_prepared_cql_query_args(object):
     if self.values is not None:
       oprot.writeFieldBegin('values', TType.LIST, 2)
       oprot.writeListBegin(TType.STRING, len(self.values))
-      for iter337 in self.values:
-        oprot.writeString(iter337)
+      for iter344 in self.values:
+        oprot.writeString(iter344)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -8527,6 +9331,216 @@ class execute_prepared_cql_query_result(object):
       oprot.trans.write(fastbinary.encode_binary(self, (self.__class__, self.thrift_spec)))
       return
     oprot.writeStructBegin('execute_prepared_cql_query_result')
+    if self.success is not None:
+      oprot.writeFieldBegin('success', TType.STRUCT, 0)
+      self.success.write(oprot)
+      oprot.writeFieldEnd()
+    if self.ire is not None:
+      oprot.writeFieldBegin('ire', TType.STRUCT, 1)
+      self.ire.write(oprot)
+      oprot.writeFieldEnd()
+    if self.ue is not None:
+      oprot.writeFieldBegin('ue', TType.STRUCT, 2)
+      self.ue.write(oprot)
+      oprot.writeFieldEnd()
+    if self.te is not None:
+      oprot.writeFieldBegin('te', TType.STRUCT, 3)
+      self.te.write(oprot)
+      oprot.writeFieldEnd()
+    if self.sde is not None:
+      oprot.writeFieldBegin('sde', TType.STRUCT, 4)
+      self.sde.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
+
+  def validate(self):
+    return
+
+
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.iteritems()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __ne__(self, other):
+    return not (self == other)
+
+class execute_prepared_cql3_query_args(object):
+  """
+  Attributes:
+   - itemId
+   - values
+   - consistency
+  """
+
+  thrift_spec = (
+    None, # 0
+    (1, TType.I32, 'itemId', None, None, ), # 1
+    (2, TType.LIST, 'values', (TType.STRING,None), None, ), # 2
+    (3, TType.I32, 'consistency', None, None, ), # 3
+  )
+
+  def __init__(self, itemId=None, values=None, consistency=None,):
+    self.itemId = itemId
+    self.values = values
+    self.consistency = consistency
+
+  def read(self, iprot):
+    if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
+      fastbinary.decode_binary(self, iprot.trans, (self.__class__, self.thrift_spec))
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.I32:
+          self.itemId = iprot.readI32();
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.LIST:
+          self.values = []
+          (_etype348, _size345) = iprot.readListBegin()
+          for _i349 in xrange(_size345):
+            _elem350 = iprot.readString();
+            self.values.append(_elem350)
+          iprot.readListEnd()
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.I32:
+          self.consistency = iprot.readI32();
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
+
+  def write(self, oprot):
+    if oprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and self.thrift_spec is not None and fastbinary is not None:
+      oprot.trans.write(fastbinary.encode_binary(self, (self.__class__, self.thrift_spec)))
+      return
+    oprot.writeStructBegin('execute_prepared_cql3_query_args')
+    if self.itemId is not None:
+      oprot.writeFieldBegin('itemId', TType.I32, 1)
+      oprot.writeI32(self.itemId)
+      oprot.writeFieldEnd()
+    if self.values is not None:
+      oprot.writeFieldBegin('values', TType.LIST, 2)
+      oprot.writeListBegin(TType.STRING, len(self.values))
+      for iter351 in self.values:
+        oprot.writeString(iter351)
+      oprot.writeListEnd()
+      oprot.writeFieldEnd()
+    if self.consistency is not None:
+      oprot.writeFieldBegin('consistency', TType.I32, 3)
+      oprot.writeI32(self.consistency)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
+
+  def validate(self):
+    if self.itemId is None:
+      raise TProtocol.TProtocolException(message='Required field itemId is unset!')
+    if self.values is None:
+      raise TProtocol.TProtocolException(message='Required field values is unset!')
+    if self.consistency is None:
+      raise TProtocol.TProtocolException(message='Required field consistency is unset!')
+    return
+
+
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.iteritems()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __ne__(self, other):
+    return not (self == other)
+
+class execute_prepared_cql3_query_result(object):
+  """
+  Attributes:
+   - success
+   - ire
+   - ue
+   - te
+   - sde
+  """
+
+  thrift_spec = (
+    (0, TType.STRUCT, 'success', (CqlResult, CqlResult.thrift_spec), None, ), # 0
+    (1, TType.STRUCT, 'ire', (InvalidRequestException, InvalidRequestException.thrift_spec), None, ), # 1
+    (2, TType.STRUCT, 'ue', (UnavailableException, UnavailableException.thrift_spec), None, ), # 2
+    (3, TType.STRUCT, 'te', (TimedOutException, TimedOutException.thrift_spec), None, ), # 3
+    (4, TType.STRUCT, 'sde', (SchemaDisagreementException, SchemaDisagreementException.thrift_spec), None, ), # 4
+  )
+
+  def __init__(self, success=None, ire=None, ue=None, te=None, sde=None,):
+    self.success = success
+    self.ire = ire
+    self.ue = ue
+    self.te = te
+    self.sde = sde
+
+  def read(self, iprot):
+    if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
+      fastbinary.decode_binary(self, iprot.trans, (self.__class__, self.thrift_spec))
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 0:
+        if ftype == TType.STRUCT:
+          self.success = CqlResult()
+          self.success.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 1:
+        if ftype == TType.STRUCT:
+          self.ire = InvalidRequestException()
+          self.ire.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRUCT:
+          self.ue = UnavailableException()
+          self.ue.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.STRUCT:
+          self.te = TimedOutException()
+          self.te.read(iprot)
+        else:
+          iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.STRUCT:
+          self.sde = SchemaDisagreementException()
+          self.sde.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
+
+  def write(self, oprot):
+    if oprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and self.thrift_spec is not None and fastbinary is not None:
+      oprot.trans.write(fastbinary.encode_binary(self, (self.__class__, self.thrift_spec)))
+      return
+    oprot.writeStructBegin('execute_prepared_cql3_query_result')
     if self.success is not None:
       oprot.writeFieldBegin('success', TType.STRUCT, 0)
       self.success.write(oprot)

--- a/pycassa/cassandra/constants.py
+++ b/pycassa/cassandra/constants.py
@@ -9,4 +9,4 @@
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
 from ttypes import *
 
-VERSION = "19.34.0"
+VERSION = "19.35.0"

--- a/pycassa/cassandra/ttypes.py
+++ b/pycassa/cassandra/ttypes.py
@@ -1544,7 +1544,7 @@ class IndexExpression(object):
 
 class IndexClause(object):
   """
-  @Deprecated: use a KeyRange with row_filter in get_range_slices instead
+  @deprecated use a KeyRange with row_filter in get_range_slices instead
 
   Attributes:
    - expressions
@@ -3015,7 +3015,7 @@ class KsDef(object):
    - name
    - strategy_class
    - strategy_options
-   - replication_factor: @deprecated, ignored
+   - replication_factor: @deprecated ignored
    - cf_defs
    - durable_writes
   """
@@ -3575,6 +3575,98 @@ class CqlPreparedResult(object):
       raise TProtocol.TProtocolException(message='Required field itemId is unset!')
     if self.count is None:
       raise TProtocol.TProtocolException(message='Required field count is unset!')
+    return
+
+
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.iteritems()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __ne__(self, other):
+    return not (self == other)
+
+class CfSplit(object):
+  """
+  Represents input splits used by hadoop ColumnFamilyRecordReaders
+
+  Attributes:
+   - start_token
+   - end_token
+   - row_count
+  """
+
+  thrift_spec = (
+    None, # 0
+    (1, TType.STRING, 'start_token', None, None, ), # 1
+    (2, TType.STRING, 'end_token', None, None, ), # 2
+    (3, TType.I64, 'row_count', None, None, ), # 3
+  )
+
+  def __init__(self, start_token=None, end_token=None, row_count=None,):
+    self.start_token = start_token
+    self.end_token = end_token
+    self.row_count = row_count
+
+  def read(self, iprot):
+    if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
+      fastbinary.decode_binary(self, iprot.trans, (self.__class__, self.thrift_spec))
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRING:
+          self.start_token = iprot.readString();
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.end_token = iprot.readString();
+        else:
+          iprot.skip(ftype)
+      elif fid == 3:
+        if ftype == TType.I64:
+          self.row_count = iprot.readI64();
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
+
+  def write(self, oprot):
+    if oprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and self.thrift_spec is not None and fastbinary is not None:
+      oprot.trans.write(fastbinary.encode_binary(self, (self.__class__, self.thrift_spec)))
+      return
+    oprot.writeStructBegin('CfSplit')
+    if self.start_token is not None:
+      oprot.writeFieldBegin('start_token', TType.STRING, 1)
+      oprot.writeString(self.start_token)
+      oprot.writeFieldEnd()
+    if self.end_token is not None:
+      oprot.writeFieldBegin('end_token', TType.STRING, 2)
+      oprot.writeString(self.end_token)
+      oprot.writeFieldEnd()
+    if self.row_count is not None:
+      oprot.writeFieldBegin('row_count', TType.I64, 3)
+      oprot.writeI64(self.row_count)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
+
+  def validate(self):
+    if self.start_token is None:
+      raise TProtocol.TProtocolException(message='Required field start_token is unset!')
+    if self.end_token is None:
+      raise TProtocol.TProtocolException(message='Required field end_token is unset!')
+    if self.row_count is None:
+      raise TProtocol.TProtocolException(message='Required field row_count is unset!')
     return
 
 


### PR DESCRIPTION
Since we are aiming for Python 2.6+ now, I regenerated the code using thrift 0.9 (using the "except Exception as e:" syntax). And then updated to the latest protocol version 19.35.0 from C\* 1.2.0-beta2.
