### PR TITLE
Use a lock around all updates to shared state.

### DIFF
--- a/pycassa/batch.py
+++ b/pycassa/batch.py
@@ -126,7 +126,7 @@ class Mutator(object):
                                   allow_retries=self.allow_retries)
             self._buffer = []
         finally:
-            if conn:
+            if conn and conn.transport.isOpen():
                 conn.return_to_pool()
             self._lock.release()
 


### PR DESCRIPTION
Prevent closed connections from ending up in the pool (Mutator uses "return_to_pool"). Since current_conns has already been decremented, the pool would reach a state where a new connection was always opened but could not be put in the queue since it was full.
