### PR TITLE
Make sure connection count is decremented as we are disposing connection...

### DIFF
--- a/pycassa/pool.py
+++ b/pycassa/pool.py
@@ -585,10 +585,10 @@ class ConnectionPool(object):
                 conn = self._q.get(False)
                 conn._dispose_wrapper(
                         reason="Pool %s is being disposed" % id(self))
+                self._decrement_overflow()
             except Queue.Empty:
                 break
 
-        self._overflow = 0 - self.size()
         self._notify_on_pool_dispose()
 
     def size(self):


### PR DESCRIPTION
...s from pool.

Also, remove unused var.

If we disposed a pool, then tried to use it again with no overflow, no connections would be created.
