### PR TITLE
If the connection is dead, decrement the # of current conns

### DIFF
--- a/pycassa/pool.py
+++ b/pycassa/pool.py
@@ -474,6 +474,8 @@ class ConnectionPool(object):
     def put(self, conn):
         """ Returns a connection to the pool. """
         if not conn.transport.isOpen():
+            with self._pool_lock:
+                self._current_conns -= 1
             return
 
         if self._pool_threadlocal:


### PR DESCRIPTION
Dead connections don't get returned to the pool now but the
number of current connections doesn't get decremented.  This
means if all of your connections end up in a dead state, then
you can't talk to anything
