### PR TITLE
Update interface to 19.36.1.

### DIFF
--- a/pycassa/cassandra/constants.py
+++ b/pycassa/cassandra/constants.py
@@ -9,4 +9,4 @@
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
 from ttypes import *
 
-VERSION = "19.35.0"
+VERSION = "19.36.1"


### PR DESCRIPTION
Update the interface adding LOCAL_ONE and populate_io_cache_on_flush.

Thrift files re-generated with the same version as your upstream so the diff is very small.
