### PR TITLE
[debian] Bump to 1.11.0 and fix lintian errors

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,14 @@
+pycassa (1.11.0) unstable; urgency=low
+
+  * Non-maintainer upload.
+  * Return timestamp from remove() in stub ColumnFamily
+  * Upgrade Thrift (adds LOCAL_ONE and populate_io_cache_on_flush)
+
+ -- Sebastien Badia <seb@sebian.fr>  Mon, 07 Apr 2014 14:51:27 +0200
+
 pycassa (1.10.0) unstable; urgency=low
 
-  * Add support for atomic batches 
+  * Add support for atomic batches
 
  -- Tyler Hobbs <tyler@datastax.com>  Thu, 03 Oct 2013 14:35:32 -0500
 

--- a/debian/control
+++ b/debian/control
@@ -1,9 +1,13 @@
 Source: pycassa
 Section: python
 Priority: optional
-Maintainer: paul cannon <paul@datastax.com>
-Build-Depends: debhelper (>= 7.0.50~), python-all, cdbs, python-support, python-sphinx, python-thrift (>= 0.5.0), python-setuptools
-Standards-Version: 3.9.1
+Maintainer: Paul Cannon <paul@datastax.com>
+Uploaders: Tyler Hobbs <tyler@datastax.com>
+Build-Depends: debhelper (>= 7.0.50~), python-all, python-support, python-sphinx, python-thrift (>= 0.5.0), python-setuptools
+Homepage: http://pycassa.github.io/pycassa/
+Vcs-Git: git://github.com/pycassa/pycassa.git
+Vcs-Browser: https://github.com/pycassa/pycassa/
+Standards-Version: 3.9.5
 
 Package: python-pycassa
 Architecture: all

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,4 @@
-Format: http://anonscm.debian.org/viewvc/dep/web/deps/dep5.mdwn?revision=174&view=co
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: pycassa
 Upstream-Contact: Tyler Hobbs <pycassa.maintainer@gmail.com>
 Source: https://github.com/pycassa/pycassa
@@ -15,3 +15,38 @@ License: Expat
 Files: pycassa/cassandra/*
 Copyright: 2009-2010 The Apache Software Foundation
 License: Apache-2
+
+License: Apache-2
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+     http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ .
+ On Debian-based systems the full text of the Apache version 2.0 license
+ can be found in `/usr/share/common-licenses/Apache-2.0'.
+
+License: Expat
+ Permission is hereby granted, free of charge, to any person obtaining a copy of
+ this software and associated documentation files (the "Software"), to deal in
+ the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do
+ so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.


### PR DESCRIPTION
Lintian fixes:
- usused-build-dependency-on-cdbs
- *-nmu (non maintainer upload)
- latest-debian-changelog-entry-changed-to-native
- missing-license-paragraph-in-dep5-copyright
